### PR TITLE
Fix accidentally creating a tuple

### DIFF
--- a/cloudcaster/cloudcaster.py
+++ b/cloudcaster/cloudcaster.py
@@ -537,7 +537,7 @@ for elb in conf['elbs']:
             if rule == None:
                 # Pack keyword arguments, then decide if 
                 kwargs = {
-                        "group_id": elb_sg.id,
+                        "group_id": str(elb_sg.id),
                         "ip_protocol": p_prot,
                         "from_port": p_from,
                         "to_port": p_to
@@ -546,7 +546,7 @@ for elb in conf['elbs']:
                 if cidr != None:
                     kwargs['cidr_ip'] = cidr
                 elif group != None:
-                    kwargs['src_security_group_group_id'] = allowsg.id,
+                    kwargs['src_security_group_group_id'] = str(allowsg.id)
 
                 if cidr != None:
                     print "Creating SG rule for ALLOWCIDR -> ELB (%s, %s, %s, %s)" % (cidr,p_from, p_to, p_prot)


### PR DESCRIPTION
< vjanelle>  549                     print type(str(allowsg.id))
< vjanelle>  550 kwargs['src_security_group_group_id'] = str(allowsg.id),
< vjanelle>  551                     print type(kwargs['src_security_group_group_id'])
< vjanelle> &lt;type 'str'&gt;
< vjanelle> &lt;type 'tuple'&gt;
< AeroNotix> 550 str(..),
< AeroNotix> notice the trailing comma
< AeroNotix> that makes it a tuple
< vjanelle> oh
< AeroNotix> Done _that_ before
< AeroNotix> lolz
< okeuday1> yeah, that is annoying
< vjanelle> AeroNotix: thanks
< vjanelle> AeroNotix: I do not know how long that would've taken me to figure out
< AeroNotix> vjanelle: such an innocuous little thing.
< AeroNotix> vjanelle: it should be a syntax error imho
