### PR TITLE
introduce app.intaddrs which are ec2 secondary IPs

### DIFF
--- a/cloudcaster/README.md
+++ b/cloudcaster/README.md
@@ -151,6 +151,7 @@ Cloudcaster uses JSON as a specification for the cloud environment to create.  A
       "group": "example-prod",
       "elb": "example",
       "elbs": [ "example", "example-int" ],
+      "azlimit": "us-east-1a",
       "ami": "ami-ccf297fc",
       "type": "t1.micro",
       "role": "discovery",
@@ -188,6 +189,9 @@ Cloudcaster uses JSON as a specification for the cloud environment to create.  A
 * **apps[].autoscale.max** - AutoScaleGroup maximum instance count
 * **apps[].extports** - array of ports to open to external public addresses of
   group members.  ie: for cassandra.
+* **apps[].azlimit** - single AZ to limit placement of instances
+* **apps[].intaddrs** - array of static internal IPs to be assigned to
+  instances once running.  May take a second pass due to startup delays.
 
 ## NETWORK
 Cloudcaster creates a VPC network as follows:

--- a/ec2rotatehosts/ec2rotatehosts
+++ b/ec2rotatehosts/ec2rotatehosts
@@ -306,6 +306,8 @@ instrotate = 0
 for thisinst in oldinst:
   thisnewinst = None
   elasticip = None
+  internalip = None
+  internaleni = None
 
   if args.num > 0 and instrotate >= args.num:
       print "%s finished rotating requested %d/%d instances" % (args.group,
@@ -326,6 +328,14 @@ for thisinst in oldinst:
       if elasticip:
           break
 
+  # Determine if Secondary IP is in use, and save for new instance
+  for i in addrinsts:
+      for ni in i.interfaces:
+          if len(ni.private_ip_addresses) > 1:
+              internalip = ni.private_ip_addresses[1].private_ip_address
+              internaleni = ni.id
+              break
+
   if not verbose:
     # first part of rotating i-xxxxxx -> i-xxxxxx
     print "%s rotating %s ->" % (args.group, thisinst),
@@ -342,6 +352,15 @@ for thisinst in oldinst:
                   elasticip.public_ip)
           sys.stdout.flush()
       elasticip.disassociate()
+
+  if internalip:
+      if verbose:
+          print "%s %s disassociating Secondary IP %s" % (args.group, thisinst,
+                  internalip)
+          sys.stdout.flush()
+      awsec2.unassign_private_ip_addresses(
+              network_interface_id=internaleni,
+              private_ip_addresses=internalip)
 
   if startfirst:
       asg = awsasg.get_all_groups([args.group])[0]
@@ -384,6 +403,19 @@ for thisinst in oldinst:
                   elasticip.public_ip)
           sys.stdout.flush()
       elasticip.associate(thisnewinst, allow_reassociation=True)
+
+  if internalip:
+      if verbose:
+          print "%s %s associating Secondary IP %s" % (args.group, thisnewinst,
+                  internalip)
+          sys.stdout.flush()
+      internaleni = None
+      for i in awsec2.get_only_instances(thisnewinst):
+          internaleni = i.interfaces[0].id
+      awsec2.assign_private_ip_addresses(
+              network_interface_id=internaleni,
+              private_ip_addresses=internalip,
+              allow_reassignment=False)
 
   # wait for new instance to register to the ELB
   elb_wait_registered(thisnewinst)


### PR DESCRIPTION
requires introduction of app.azlimit which limits the availability zones
for an instance / autoscale group to a single AZ.  Subnets cannot span
AZs, so this is the only option.

ec2rotatehosts now detects the first secondary address and preserves it
