### PR TITLE
Expose ELB idle timeout settings

### DIFF
--- a/cloudcaster/examples/example.json
+++ b/cloudcaster/examples/example.json
@@ -48,7 +48,8 @@
       "interval": 20,
       "healthy": 3,
       "unhealthy": 5,
-      "target": "HTTP:80/"
+      "target": "HTTP:80/",
+      "idle_timeout": 3600  
     }
   ],
 


### PR DESCRIPTION
This requires that an ELB's configuration has a field called
'idle_timeout' which is the timeout in seconds.
