### PR TITLE
fix boto >= 2.34

### DIFF
--- a/cloudcaster/cloudcaster.py
+++ b/cloudcaster/cloudcaster.py
@@ -28,7 +28,16 @@
 # Thanks to Mahesh Paolini-Subramanya (@dieswaytoofast) for his help
 #
 import argparse
-import boto
+import sys
+try:
+    import boto
+except ImportError:
+    print 'boto required'
+    sys.exit(1)
+from distutils.version import LooseVersion
+if LooseVersion(boto.Version) < LooseVersion("2.34.0"):
+    print 'boto >= 2.34.0 required'
+    sys.exit(1)
 import boto.ec2
 import boto.ec2.autoscale
 import boto.ec2.elb
@@ -40,7 +49,6 @@ import datetime
 import json
 import os
 import re
-import sys
 import time
 import yaml
 import copy


### PR DESCRIPTION
ref: https://github.com/boto/boto/commit/e57b7fc31ae237df5439459d602651ed3cc10557?diff=split

This removes the workaround for boto counting 0,1,2,4 fixed in 2.34
