### PR TITLE
ec2nodefind - allow public without other switches

### DIFF
--- a/ec2nodefind/ec2nodefind
+++ b/ec2nodefind/ec2nodefind
@@ -162,7 +162,10 @@ for inst in running:
       else:
         outfile.write("%s\n" % i.private_dns_name)
     else:
-      outfile.write("%s\n" % i.private_dns_name.split('.')[0])
+      if args.public == True:
+        outfile.write("%s\n" % i.public_dns_name.split('.')[0])
+      else:
+        outfile.write("%s\n" % i.private_dns_name.split('.')[0])
 
 if args.filename != None:
   outfile.close()


### PR DESCRIPTION
Pet peeve: Bare ec2nodefind returned private short dns name but
bare with public returned null.
