### PR TITLE
Stop saying when the carpet matches the drapes

### DIFF
--- a/cloudcaster/cloudcaster.py
+++ b/cloudcaster/cloudcaster.py
@@ -942,7 +942,7 @@ for confelb in conf['elbs']:
         else:
             conf_idle_timeout = None
 
-        if (conf_idle_timeout != None and \
+        if (conf_idle_timeout != None and
                 elb_attr.connecting_settings.idle_timeout != conf_idle_timeout):
             print "Idle timeout on %s not set to %s" % (elb.name, conf_idle_timeout)
             elb_attr = boto.ec2.elb.attributes.ConnectionSettingAttribute(
@@ -953,12 +953,13 @@ for confelb in conf['elbs']:
             if not elb.connection.modify_lb_attribute(myname, attr, elb_attr):
                 print "Failed modifying ELB settings %s" % myname
                 sys.exit(1)
-        elif (conf_idle_timeout == None and \
+        elif (conf_idle_timeout == None and
                 elb_attr.connecting_settings.idle_timeout == 60):
             # default is 60
             pass
         else:
-            print "WARNING: %s timeout set to %s, and config says %s!!!!!!!" % (elb.name, elb_attr.connecting_settings.idle_timeout, conf_idle_timeout)
+            if elb_attr.connecting_settings.idle_timeout != conf_idle_timeout:
+                print "WARNING: %s timeout set to %s, and config says %s!!!!!!!" % (elb.name, elb_attr.connecting_settings.idle_timeout, conf_idle_timeout)
 
     if elb == None:
         print "Creating ELB %s" % myname
@@ -1193,7 +1194,7 @@ for app in conf['apps']:
             if 'keypair' in app:
                 key_name = app['keypair']
             else:
-                print "WARNING, creating %s without a keypair!!" % ( app['name'] )
+                print "WARNING, creating %s without a keypair!!" % (app['name'])
             if 'azlimit' in app:
                 subnetidx = conf['vpc']['azs'].index(app['azlimit'])
             if 'public' in app:
@@ -1449,7 +1450,7 @@ for app in conf['apps']:
             if 'keypair' in app:
                 key_name = app['keypair']
             else:
-                print "WARNING: Staring %s without a keypair!!!" % ( app['name'] )
+                print "WARNING: Staring %s without a keypair!!!" % (app['name'])
 
             lckwargs = {
                 "name": asgnamefull,


### PR DESCRIPTION
Fixes a warning where cloudcaster will spit out that the elb and config
file match.

Also ran it through autopep8.